### PR TITLE
370

### DIFF
--- a/lakeshore/__init__.py
+++ b/lakeshore/__init__.py
@@ -1,12 +1,35 @@
 """Python driver for Lake Shore instruments"""
+
 from .generic_instrument import InstrumentException
 from .xip_instrument import XIPInstrumentException
 from .em_power_supply import ElectromagnetPowerSupply, Model643, Model648
-from .teslameter import Teslameter, TeslameterOperationRegister, TeslameterQuestionableRegister, F41, F71
-from .fast_hall_controller import FastHall, FastHallOperationRegister, FastHallQuestionableRegister, ContactCheckManualParameters,\
-    ContactCheckOptimizedParameters, FastHallManualParameters, FastHallLinkParameters, FourWireParameters,\
-    DCHallParameters, ResistivityManualParameters, ResistivityLinkParameters, M91
-from .model_155 import PrecisionSource, PrecisionSourceOperationRegister, PrecisionSourceQuestionableRegister, Model155
+from .teslameter import (
+    Teslameter,
+    TeslameterOperationRegister,
+    TeslameterQuestionableRegister,
+    F41,
+    F71,
+)
+from .fast_hall_controller import (
+    FastHall,
+    FastHallOperationRegister,
+    FastHallQuestionableRegister,
+    ContactCheckManualParameters,
+    ContactCheckOptimizedParameters,
+    FastHallManualParameters,
+    FastHallLinkParameters,
+    FourWireParameters,
+    DCHallParameters,
+    ResistivityManualParameters,
+    ResistivityLinkParameters,
+    M91,
+)
+from .model_155 import (
+    PrecisionSource,
+    PrecisionSourceOperationRegister,
+    PrecisionSourceQuestionableRegister,
+    Model155,
+)
 from .model_121 import Model121
 from .model_224 import *
 from .model_240 import *
@@ -14,9 +37,14 @@ from .model_335 import *
 from .model_336 import *
 from .model_336 import Model336
 from .model_350 import Model350
+from .model_370 import Model370
 from .model_372 import *
 from .model_425 import Model425
-from .ssm_system import SSMSystem, SSMSystemQuestionableRegister, SSMSystemOperationRegister
+from .ssm_system import (
+    SSMSystem,
+    SSMSystemQuestionableRegister,
+    SSMSystemOperationRegister,
+)
 from .ssm_system_enums import SSMSystemEnums
 from .ssm_base_module import SSMSystemModuleQuestionableRegister
 from .ssm_measure_module import SSMSystemMeasureModuleOperationRegister

--- a/lakeshore/model_370.py
+++ b/lakeshore/model_370.py
@@ -1,0 +1,110 @@
+"""Implements functionality unique to the Lake Shore Model 370 AC bridge and temperature controller.
+NOTE: This is an incomplete implmentation that only supports serial. The available API for the 370 is also
+only minimally supported.
+"""
+
+from .model_370_enums import Model370Enums
+from .temperature_controllers import TemperatureController, StandardEventRegister
+from .generic_instrument import RegisterBase
+
+# 370 uses the standard layout for the standard event register
+Model370StandardEventRegister = StandardEventRegister
+
+
+## Unique register layouts ##
+class Model370StatusByteRegister(RegisterBase):
+    """
+    Status byte register is read-only and has flags signaling
+    specific reports by the system (Section 6.1.4), if enabled via the
+    Service Request Enable Register. The Serivce Request Enable
+    Register is isomorphic and will be aliased (it's just read/write).
+    Stored here from LSB to MSB.
+    """
+
+    bit_names = [
+        "",
+        "",
+        "settle",
+        "alarm",
+        "error",
+        "standard_event_status",
+        "service_request",
+        "ramp_done",
+    ]
+
+    def __init__(
+        self,
+        ramp_done: bool,
+        service_request: bool,
+        standard_event_status: bool,
+        error: bool,
+        alarm: bool,
+        settle: bool,
+    ):
+        self.settle = settle
+        self.alarm = alarm
+        self.error = error
+        self.std_event_status = standard_event_status
+        self.service_request = service_request
+        self.ramp_done = ramp_done
+
+
+Model370ServiceRequestEnable = Model370StatusByteRegister
+
+
+## Controller class def ##
+class Model370(TemperatureController, Model370Enums):
+    """
+    Implements the Model 370 high-level API. Incomplete, check enums.
+    """
+
+    # Initialize registers
+    _status_byte_register = Model370StatusByteRegister
+    _service_request_enable = Model370ServiceRequestEnable
+
+    def __init__(
+        self,
+        baud_rate: int,
+        vid: int,
+        pid: int,
+        serial_number: str | None = None,
+        com_port: str | None = None,
+        timeout: float = 2.0,
+        ip_address: None = None,  # Not supported on 370
+        tcp_port: None = None,  # Not supported on 370
+    ):
+
+        # Set instance value of vid_pid since this can change across 340s due to USB-to-Serial converters
+        # (as opposed to being the same for devices with built-in USB ports).
+        self.vid_pid = [(vid, pid)]
+
+        # Call the parent init, then fill in values specific to the 340
+        TemperatureController.__init__(
+            self,
+            serial_number=serial_number,
+            com_port=com_port,
+            timeout=timeout,
+            baud_rate=baud_rate,
+            ip_address=ip_address,
+            tcp_port=tcp_port,
+        )
+
+    def get_kelvin_reading(self, input_channel):
+        """Returns the temperature value in kelvin of the given channel.
+
+        Args:
+            input_channel:
+                Selects the channel to retrieve measurement.
+
+        """
+        return float(self.query(f"RDGK? {input_channel}"))
+
+    def get_sensor_reading(self, input_channel):
+        """Returns the sensor reading in Ohms.
+
+        Returns:
+            reading (float):
+                The raw sensor reading in the units of the connected sensor.
+
+        """
+        return float(self.query(f"RDGR? {input_channel}"))

--- a/lakeshore/model_370.py
+++ b/lakeshore/model_370.py
@@ -97,7 +97,7 @@ class Model370(TemperatureController, Model370Enums):
                 Selects the channel to retrieve measurement.
 
         """
-        return float(self.query(f"RDGK? {input_channel}"))
+        return float(self.query(f"RDGK? {input_channel}", check_errors=False))
 
     def get_sensor_reading(self, input_channel):
         """Returns the sensor reading in Ohms.
@@ -107,4 +107,4 @@ class Model370(TemperatureController, Model370Enums):
                 The raw sensor reading in the units of the connected sensor.
 
         """
-        return float(self.query(f"RDGR? {input_channel}"))
+        return float(self.query(f"RDGR? {input_channel}", check_errors=False))

--- a/lakeshore/model_370.py
+++ b/lakeshore/model_370.py
@@ -1,5 +1,5 @@
 """Implements functionality unique to the Lake Shore Model 370 AC bridge and temperature controller.
-NOTE: This is an incomplete implmentation that only supports serial. The available API for the 370 is also
+NOTE: This is an incomplete implementation that only supports serial. The available API for the 370 is also
 only minimally supported.
 """
 

--- a/lakeshore/model_370_enums.py
+++ b/lakeshore/model_370_enums.py
@@ -1,0 +1,7 @@
+"""Implements a class containing the enums relevant to the Model 370."""
+
+from enum import IntEnum, Enum
+
+
+class Model370Enums:
+    pass


### PR DESCRIPTION
Added minimal support for the model 370 AC resistance bridge which is officially unsupported by the driver due to lack of USB and/or ethernet.